### PR TITLE
refactor: improve nginx Dockerfile build time

### DIFF
--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -27,9 +27,10 @@ RUN rc-update add nginx
 RUN rm -rf /etc/nginx
 COPY config/nginx /etc/nginx
 
-RUN rm -rf /usr/local/etc/php
-RUN rm -rf /usr/local/etc/php-fpm.d
-RUN rm -rf /usr/local/etc/php-fpm.conf
+RUN rm -rf /usr/local/etc/php && \
+  rm -rf /usr/local/etc/php-fpm.d && \
+  rm -rf /usr/local/etc/php-fpm.conf
+
 COPY config/php82/php /usr/local/etc/php
 COPY config/php82/php-fpm.d /usr/local/etc/php-fpm.d
 COPY config/php82/php-fpm.conf /usr/local/etc/php-fpm.conf
@@ -41,30 +42,24 @@ ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/do
 
 RUN chmod +x /usr/local/bin/install-php-extensions
 
-RUN install-php-extensions mbstring
-RUN install-php-extensions bcmath
-RUN install-php-extensions ctype
-RUN install-php-extensions curl
-RUN install-php-extensions dom
-RUN install-php-extensions fileinfo
-RUN install-php-extensions filter
-RUN install-php-extensions gd
-RUN install-php-extensions intl
-RUN install-php-extensions pdo_mysql
-RUN install-php-extensions simplexml
-RUN install-php-extensions soap
-RUN install-php-extensions sockets
-RUN install-php-extensions sodium
-RUN install-php-extensions xmlwriter
-RUN install-php-extensions xsl
-RUN install-php-extensions zip
-RUN install-php-extensions @composer
+RUN install-php-extensions \
+  mbstring \
+  bcmath \
+  ctype \
+  curl \
+  dom \
+  fileinfo \
+  filter \
+  gd \
+  intl \
+  pdo_mysql \
+  simplexml \
+  soap \
+  sockets \
+  sodium \
+  xmlwriter \
+  xsl \
+  zip\
+  @composer
 
 # --------------------------------------
-
-
-
-
-
-
-


### PR DESCRIPTION
## Merge Request - Melhoria no tempo de build da imagem do nginx

### Descrição
Ao colocar todas as instalações de extensões do PHP em um único comando RUN, estamos criando uma única camada na imagem Docker, o que significa que o Docker não precisa criar camadas adicionais para cada comando RUN separado. Isso ajuda a reduzir o tamanho da imagem e acelerar o processo de construção. Além disso, reduz o número de operações de I/O, pois o Docker precisa copiar menos dados entre a máquina host e a imagem Docker em construção.

### Resultado
- Quantidade de layers diminui de 44 para 25.
- Processo de build ficou cerca de 51% mais rapido
- Não se obteve ganho significativo no tamanho final da imagem (em torno de 1MB)

### Anexos

#### Tempo de build anteriormente:
![image](https://user-images.githubusercontent.com/23709005/233854022-8b53171a-6270-48a5-8cfc-9034711bdb71.png)


#### Tempo de build após o refactor:
![image](https://user-images.githubusercontent.com/23709005/233854671-55751a7c-a057-4d5e-a237-e6cf180a7f7c.png)


